### PR TITLE
WIP: DocumentJupyterConverter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "doctrine": "^2.0.0",
     "js-beautify": "^1.7.4",
-    "jsbeautify": "^0.3.6",
     "memfs": "^2.5.8",
     "substance": "^1.0.0-beta.7-preview.11"
   },

--- a/src/document/DocumentConverter.js
+++ b/src/document/DocumentConverter.js
@@ -1,0 +1,9 @@
+import Converter from '../Converter'
+
+export default class DocumentConverter extends Converter {
+
+  _createDOM () {
+    return super._createDOM('document')
+  }
+
+}

--- a/src/document/DocumentJupyterConverter.js
+++ b/src/document/DocumentJupyterConverter.js
@@ -1,0 +1,297 @@
+// Use Substance's DOM implementation (works in browser and in node). See
+//    https://github.com/substance/substance/blob/develop/dom/DOMElement.js
+// for the API
+import {DefaultDOMElement} from 'substance'
+
+// Standard language codes
+import * as language from '../language'
+
+// Markdown <-> HTML conversion for Jupyter Markdown cells
+import MarkdownConverter from '../document/DocumentMarkdownConverter'
+const markdownConverter = new MarkdownConverter()
+const md2html = md => markdownConverter.importContent(md)
+const html2md = html => markdownConverter.exportContent(html)
+
+// Cell value <-> HTML conversion for Jupyter code cell outputs
+import {fromHTML, toHTML, fromMime, toMime} from '../value'
+
+/**
+ * Jupyter notebook converter for the Stencila Documents
+ *
+ * Converts a document from/to a Jupyter Notebook based on
+ * the documentation of the notebook format at
+ *
+ *   https://github.com/jupyter/nbformat
+ *
+ * See there for JSON schemas too
+ *
+ *   e.g. https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
+ */
+export default class DocumentJupyterConverter {
+
+  /**
+   * Is a file name to be converted using this converter? 
+   * 
+   * @param  {string} fileName - Name of file
+   * @return {boolean} - Is the file name matched?
+   */
+  static match (fileName) {
+    return fileName.slice(-6) === '.ipynb'
+  }
+
+  // Import a document from storer to buffer
+  // This method is likely to be refactored into a base class method
+  // since it is very similar for all single-file based converters e.g. DocumentMarkdownConverter
+  importDocument(storer, buffer) {
+    let mainFilePath = storer.getMainFilePath()
+    let manifest = {
+      "type": "document",
+      "storage": {
+        "external": storer.isExternal(),
+        "storerType": storer.getType(),
+        "archivePath": storer.getArchivePath(),
+        "mainFilePath": mainFilePath,
+        "contentType": "ipynb",
+      },
+      "createdAt": new Date(),
+      "updatedAt": new Date()
+    }
+    return storer.readFile(
+      mainFilePath,
+      'text/html'
+    ).then(json => {
+      let html = `<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <main>
+      <div id="data" data-format="html">
+        <div class="content">${this.importContent(json)}</div>
+      </div>
+    </main>
+  </body>
+</html>`
+      return buffer.writeFile(
+        'index.html',
+        'text/html',
+        html
+      )
+    }).then(() => {
+      return buffer.writeFile(
+        'stencila-manifest.json',
+        'application/json',
+        JSON.stringify(manifest, null, '  ')
+      )
+    }).then(() => {
+      return manifest
+    })
+  }
+
+  // Export a document from buffer to storer
+  // This method is likely to be refactored into a base class method
+  // since it is very similar for all single-file based converters e.g. DocumentMarkdownConverter
+  exportDocument(buffer, storer) {
+    return buffer.readFile('index.html', 'text/html').then((html) => {
+      let content = DefaultDOMElement.parseHTML(html).find('.content')
+      if (!content) throw new Error('No div.content element in HTML!')
+      let ipynb = this.exportContent(content.getInnerHTML())
+      return storer.writeFile(storer.getMainFilePath(), 'text/json', ipynb)
+    })
+  }
+
+  /**
+   * Convert from a Jupyter Notebook to a Stencila Document
+   *
+   * @memberof document/jupyter
+   *
+   * @param  {string|object} json - Content of Jupyter Notebook (JSON string of Object)
+   * @return {string} Content of Stencila Document (HTML)
+   */
+  importContent (json) {
+    // Get notebook data, by parsing JSON string if necessary
+    let data = (typeof json === 'string') ? JSON.parse(json) : json
+
+    let doc = DefaultDOMElement.createDocument('html')
+    let $$ = doc.createElement.bind(doc)
+    let root = $$('div')
+
+    // Get notebook metadata
+    let metadata = data.metadata
+
+    // Get notebook language
+    let lang
+    if (metadata) {
+      if (metadata.language_info) {
+        lang = metadata.language_info.name
+      } else if (metadata.kernelspec) {
+        lang = metadata.kernelspec.language
+      } else if (metadata.kernel_info) {
+        lang = metadata.kernel_info.language
+      }
+    }
+    lang = language.shortname(lang || '') || ''
+
+    // Get cells
+    let cells
+    if (data.cells) {
+      cells = data.cells
+    } else if (data.worksheets) {
+      // In nbformat 3.0 there is an array called worksheets, each having cells
+      cells = data.worksheets[0].cells
+    }
+
+    // Convert each cell
+    for (let cell of cells) {
+      let source = cell.source.join('')
+
+      // Remove the trailing newline, otherwise we get an extra line when dumping
+      if (source.slice(-1) === '\n') source = source.slice(0, -1)
+
+      if (cell.cell_type === 'markdown') {
+        // Convert Markdown to HTML and insert into the document
+        let html = md2html(source)
+        let el = DefaultDOMElement.parseSnippet(`<div>${html}</div>`, 'html')
+        for (let child of el.children) root.append(child)
+      } else if (cell.cell_type === 'code') {
+        // Create a Stencila global cell
+        let scell = $$('div').attr('data-cell', `global ${lang}()`)
+        scell.append(
+          $$('pre').attr('data-source', '').text(source)
+        )
+
+        // Process outputs
+        let outputs = cell.outputs
+        if (outputs) {
+          for (let output of outputs) {
+            let type = output.output_type
+            if (type === 'execute_result' || type === 'display_data') {
+              // Get output mimetype and content
+              // Currently just use the first mime type (there may be multiple
+              // formats for the output)
+              let mimebundle = output.data
+              let mimetype = Object.keys(mimebundle)[0]
+              let content = mimebundle[mimetype]
+              if (content.constructor.name === 'Array') content = content.join('')
+              // Convert MIME type/content to HTML and append to scell
+              let value = fromMime(mimetype, content)
+              let html = toHTML(value)
+              // Parse HTML into an element and append
+              let el = DefaultDOMElement.parseSnippet(html, 'html')
+              scell.append(el)
+            } else if (type === 'stream') {
+              let out = $$('pre')
+              if (output.name === 'stderr') out.attr('data-error', '')
+              else {
+                out.attr('data-value', 'str')
+                out.attr('data-format', 'text')
+              }
+              out.text(output.text.join(''))
+              scell.append(out)
+            } else if (type === 'error') {
+              let error = $$('pre').attr('data-error', '')
+              error.text(output.ename + ': ' + output.evalue + '\n\n' + output.traceback)
+              scell.append(error)
+            }
+          }
+        }
+
+        root.append(scell)
+      }
+    }
+
+    let html = root.html()
+    return html
+  }
+
+  /**
+   * Convert to a Jupyter Notebook from a Stencila Document
+   *
+   * @memberof document/jupyter
+   *
+   * @param {string} html - Document HTML string
+   * @return {string|object} - Jupyter notebook JSON or object
+   */
+  exportContent (html, options) {
+    options = options || {}
+    if (options.stringify !== false) options.stringify = true
+    if (options.pretty !== false) options.pretty = true
+
+    // Initial, empty notebook object
+    let nb = {
+      cells: [],
+      metadata: {}, // TODO lang from executes - ensure only one
+      nbformat: 4,
+      nbformat_minor: 2
+    }
+
+    // Create a DOM document to iterate over
+    let root = DefaultDOMElement.parseSnippet(`<div>${html}</div>`, 'html')
+
+    // We need to accumulate HTML elements which are then flushed
+    // into a markdown cell when a Stencila cell is hit, or at end
+    let buffer = ''
+    function flush () {
+      if (buffer) {
+        let md = html2md(buffer)
+        let lines = md.split('\n').map(line => `${line}\n`)
+        nb.cells.push({
+          cell_type: 'markdown',
+          metadata: {},
+          source: lines
+        })
+      }
+      buffer = ''
+    }
+
+    root.children.forEach(child => {
+      if (child.is('[data-cell]')) {
+        // Flush any HTML into a Markdown cell
+        flush()
+
+        // Create source lines
+        let source = child.find(['[data-source]']).text()
+
+        let lines = source.split('\n').map(line => `${line}\n`)
+
+        // Create outputs
+        let outputs = []
+        child.findAll(['[data-value]']).forEach(elem => {
+          let value = fromHTML(elem)
+          let mime = toMime(value)
+          let mimebundle = {}
+          mimebundle[mime.mimetype] = mime.content
+          let output = {
+            output_type: 'execute_result',
+            data: mimebundle
+          }
+          outputs.push(output)
+        })
+
+        nb.cells.push({
+          cell_type: 'code',
+          metadata: {}, // TODO
+          source: lines,
+          outputs: outputs,
+          execution_count: null // TODO
+        })
+      } else {
+        // Accumulate HTML buffer
+        buffer += child.outerHTML
+      }
+    })
+    // Flush any remaining HTML into a Markdown cell
+    flush()
+
+    let content
+    if (options.stringify) {
+      content = JSON.stringify(nb, null, options.pretty ? '  ' : null)
+    } else {
+      content = nb
+    }
+
+    return content
+  }
+
+}

--- a/src/document/DocumentMarkdownConverter.js
+++ b/src/document/DocumentMarkdownConverter.js
@@ -1,0 +1,5 @@
+import DocumentPandocConverter from './DocumentPandocConverter'
+
+export default class DocumentMarkdownConverter extends DocumentPandocConverter {
+
+}

--- a/src/document/DocumentPandocConverter.js
+++ b/src/document/DocumentPandocConverter.js
@@ -1,0 +1,5 @@
+import DocumentConverter from './DocumentConverter'
+
+export default class DocumentPandocConverter extends DocumentConverter {
+
+}

--- a/test/document/DocumentJupyterConverter.test.js
+++ b/test/document/DocumentJupyterConverter.test.js
@@ -1,0 +1,261 @@
+import test from 'tape'
+import {DefaultDOMElement} from 'substance'
+
+import DocumentJupyterConverter from '../../src/document/DocumentJupyterConverter'
+
+test('DocumentJupyterConverter:match', function (t) {
+  t.ok(DocumentJupyterConverter.match('foo.ipynb'))
+  t.notOk(DocumentJupyterConverter.match('foo.html'))
+  t.end()
+})
+
+test('DocumentJupyterConverter:encodingLessThan', function (t) {
+  // Tests character encoding by DefaultDOMElement
+  let el = DefaultDOMElement.createElement('pre')
+
+  el.text('Less than < char')
+  t.equal(el.text(), 'Less than < char')
+
+  el.html('Less than < char')
+  t.equal(el.html(), 'Less than &lt; char')
+
+  el.text('Less than &lt; char')
+  t.equal(el.text(), 'Less than &lt; char')
+
+  el.html('Less than &lt; char')
+  t.equal(el.html(), 'Less than &lt; char')
+
+  t.end()
+})
+
+
+test('DocumentJupyterConverter:import', t => {
+  const converter = new DocumentJupyterConverter()
+  const i = json => converter.importContent(json)
+
+  t.equal(
+    i('{"cells":[{"cell_type":"markdown","source":["# Heading 1\\n"]}]}'),
+    '<h1 id="heading-1">Heading 1</h1>',
+    'can be called with a JSON string'
+  )
+
+  t.equal(
+    i({cells: [{cell_type: 'markdown', source: ['# Heading 1\n']}]}),
+    '<h1 id="heading-1">Heading 1</h1>',
+    'can be called with Javascript object'
+  )
+
+  t.equal(
+    i({
+      metadata: { language_info: { name: 'python' } },
+      cells: [
+        {cell_type: 'markdown', source: ['# Heading 1\n']},
+        {cell_type: 'code', source: ['dict(foo="bar")\n']}
+      ]
+    }),
+    '<h1 id="heading-1">Heading 1</h1><div data-cell="global py()"><pre data-source="">dict(foo="bar")</pre></div>',
+    'cells'
+  )
+
+  t.equal(
+    i({
+      metadata: { language_info: { name: 'python' } },
+      cells: [
+        {cell_type: 'code', source: ['dict(foo=\'bar\')\n']}
+      ]
+    }),
+    '<div data-cell="global py()"><pre data-source="">dict(foo=\'bar\')</pre></div>',
+    'code cells with apostrophes'
+  )
+
+  t.equal(
+    i({cells: [{cell_type: 'markdown', source: ['```\n', 'let x = 56\n', 'x < 65\n', '```\n']}]}),
+    '<pre><code>let x = 56\nx &lt; 65</code></pre>',
+    'Markdown code block'
+  )
+
+  t.equal(
+    i({
+      metadata: { language_info: { name: 'R' } },
+      cells: [
+        {
+          cell_type: 'code',
+          source: ['x <- 6\n', 'plot(1,x)\n'],
+          outputs: [
+            {
+              output_type: 'execute_result',
+              data: {
+                'image/png': 'PNGdata'
+              }
+            }
+          ]
+        }
+      ]
+    }),
+    '<div data-cell="global r()"><pre data-source="">x &lt;- 6\nplot(1,x)</pre><img data-value="image" data-format="src" src="data:image/png;base64,PNGdata"></div>',
+    'cells with output'
+  )
+
+  t.end()
+})
+
+test('DocumentJupyterConverter:export', t => {
+  const converter = new DocumentJupyterConverter()
+  const e = (html, options) => {
+    options = options || {}
+    return converter.exportContent(html, options)
+  }
+
+  t.equal(
+    e('<h1 id="heading-1">Heading 1</h1>'),
+`{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Heading 1\\n"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 2
+}`,
+  'defaults to pretty')
+
+  t.equal(
+    e('<h1 id="heading-1">Heading 1</h1>', {pretty: false}),
+    '{"cells":[{"cell_type":"markdown","metadata":{},"source":["# Heading 1\\n"]}],"metadata":{},"nbformat":4,"nbformat_minor":2}',
+    'can set pretty false'
+  )
+  t.deepEqual(
+    e('<h1 id="heading-1">Heading 1</h1>', {stringify: false}),
+    {cells: [{cell_type: 'markdown', metadata: {}, source: ['# Heading 1\n']}], metadata: {}, nbformat: 4, nbformat_minor: 2},
+    'can set stringify false'
+  )
+
+  t.deepEqual(
+    e(`
+      <h1 id="heading-1">Heading 1</h1>
+      <div data-cell="global r()">
+        <pre data-source="">x &lt;- 6
+x*7</pre>
+        <img data-value="image" data-format="src" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8">
+      </div>`, {stringify: false}
+    ),
+    {
+      cells: [
+        {
+          cell_type: 'markdown',
+          metadata: {},
+          source: [
+            '# Heading 1\n'
+          ]
+        },
+        {
+          cell_type: 'code',
+          metadata: {},
+          source: [
+            'x <- 6\n',
+            'x*7\n'
+          ],
+          outputs: [
+            {
+              output_type: 'execute_result',
+              data: {
+                'image/png': 'iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8'
+              }
+            }
+          ],
+          execution_count: null
+        }
+      ],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 2
+    },
+    'mix dom content and cells'
+  )
+
+  t.end()
+})
+
+test('DocumentJupyterConverter:import+export', t => {
+  const converter = new DocumentJupyterConverter()
+  // Function to do round trip conversion and checking.
+  // Takes an array of cells
+  function f (cells, message) {
+    let nb = {
+      cells: cells,
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 2
+    }
+    let html = converter.importContent(nb)
+    let json = converter.exportContent(html, {stringify: false})
+    t.deepEqual(json, nb, message)
+  }
+
+  f([
+    {
+      cell_type: 'markdown',
+      metadata: {},
+      source: [
+        '# Heading 1\n',
+        '\n',
+        'Paragraph one\n'
+      ]
+    }
+  ], 'just markdown cells')
+
+  f([
+    {
+      cell_type: 'markdown',
+      metadata: {},
+      source: [
+        '# Heading 1\n',
+        '\n',
+        'Paragraph one\n',
+        '\n',
+        'Paragraph two\n'
+      ]
+    }, {
+      cell_type: 'code',
+      execution_count: null,
+      metadata: {},
+      outputs: [],
+      source: [
+        'x = 6\n',
+        'y = 7\n'
+      ]
+    }, {
+      cell_type: 'markdown',
+      metadata: {},
+      source: [
+        'Paragraph three\n'
+      ]
+    }
+  ], 'mixed markdown and code cells')
+
+  f([
+    {
+      cell_type: 'markdown',
+      metadata: {},
+      source: [
+        'Less than < character\n'
+      ]
+    }, {
+      cell_type: 'code',
+      execution_count: null,
+      metadata: {},
+      outputs: [],
+      source: [
+        'x <- 6\n',
+        'y <- 7\n'
+      ]
+    }
+  ], 'conversion of < chars')
+
+  t.end()
+})

--- a/test/document/DocumentMarkdownConverter.test.js
+++ b/test/document/DocumentMarkdownConverter.test.js
@@ -1,0 +1,32 @@
+import test from 'tape'
+
+import DocumentMarkdownConverter from '../../src/document/DocumentMarkdownConverter'
+
+const converter = new DocumentMarkdownConverter()
+
+function testLoad(name, md, xml) {
+  test(name, (assert) => {
+    converter.load(md).then((result) => {
+      assert.equal(result.trim(), xml.trim())
+      assert.end()
+    }).catch((error) => {
+      assert.fail(error)
+      assert.end()
+    })
+  })
+}
+
+
+testLoad(
+'DocumentMarkdownConverter.load paragraphs',
+`
+Paragraph 1
+
+Paragraph2
+`,
+`
+<p>Paragraph1</p>
+<p>Paragraph2</p>
+`
+)
+


### PR DESCRIPTION
The `DocumentJupyterConverter` class provides conversion between Jupyter Notebooks .ipynb JSON format and Stencila Documents

See previous iteration of this in https://github.com/stencila/stencila/pull/292

@hamishmack : this will need to call `DocumentMarkdownConverter` for doing the conversion of Markdown cells to/from JATS so will wait on that before progressing this.