### PR TITLE
refactor: allow for supplying raw content

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
   setupFilesAfterEnv: ['jest-expect-message'],
-  coveragePathIgnorePatterns: []
+  coveragePathIgnorePatterns: ['tests/helpers.ts']
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,20 +101,24 @@ interface Compiler {
  * string of raw content (e.g. `This is some Markdown`) or as a file system
  * path. This function, assesses whether a file is a file system path or not.
  *
- * If the string starts with `/`, `./` or `../` then it is assumed to be a path
- * but the presence of the path is not checked. For all other strings, this function
- * returns true if the file exists.
+ * If the string starts with `/`, `./`, `../` (or Windows compatible backslash
+ * equivalents as well as drive letter prefixed strings e.g. `C:\`)
+ * then it is assumed to be a path but the presence of the path is not checked.
+ * The reason for not checking presence
+ * here is because "if the content looks like a path then the user probably meant
+ * it to be a path". That is, if a user tries to convert the string "./file.md" then,
+ * if that file doesn't exist, she probably wants the Markdown converter to give me an error
+ * message. She probably doesn't want the `match` function to try and find some other converter
+ * that acts on a plain strings.
+ *
+ * For all other strings, this function does check for presence, returning `true`
+ * if the file exists.
  *
  * @param content The string to assess.
  */
 export function isPath(content: string): boolean {
-  if (
-    content.startsWith('/') ||
-    content.startsWith('./') ||
-    content.startsWith('../')
-  ) {
+  if (/^(\/)|(\\)|([A-Z]:\\)|(\.(\/|\\))|(\.\.(\/|\\))/.test(content))
     return true
-  }
   if (fs.existsSync(content)) return true
   return false
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import stencila from '@stencila/schema'
+import fs from 'fs-extra'
 import getStdin from 'get-stdin'
 import mime from 'mime'
 import path from 'path'
@@ -20,7 +21,7 @@ type VFile = vfile.VFile
  * Note that order is of importance for matching. More "generic"
  * formats should go last. See the `match` function.
  */
-const compilerList: Array<Compiler> = [
+export const compilerList: Array<Compiler> = [
   //  gdoc,
   //  rpng,
   ods,
@@ -55,7 +56,7 @@ interface Compiler {
   /**
    * Any array of file names to use to match the compiler.
    * This can be useful for differentiating between
-   * flavours of formats like JSON e.g. `datapackage.json` versus any old `.json` file.
+   * "flavors" of formats e.g. `datapackage.json` versus any old `.json` file.
    */
   fileNames?: Array<string>
 
@@ -67,10 +68,12 @@ interface Compiler {
   extNames?: Array<string>
 
   /**
-   * A function that does directory or [content sniffing](https://en.wikipedia.org/wiki/Content_sniffing)
-   * to determine if the compiler is able to parse the content.
+   * A function that does [content sniffing](https://en.wikipedia.org/wiki/Content_sniffing)
+   * to determine if the compiler is able to parse the content. As well as raw content, the content
+   * string could be a file system path and the compiler could do "sniffing" of the file system
+   * (e.g. testing if certain files are present in a directory).
    */
-  sniff?: (filePath: string) => Promise<boolean>
+  sniff?: (content: string) => Promise<boolean>
 
   /**
    * Parse a `Vfile` to a `stencila.Node`.
@@ -92,33 +95,66 @@ interface Compiler {
 }
 
 /**
- * Match the compiler based on file name, extension name, media/type or by content sniffing.
+ * Is a string a file system path?
  *
- * Iterates through the compilers and returns that matches any of the criteria.
+ * Several functions in this module allow for content to be passed as a
+ * string of raw content (e.g. `This is some Markdown`) or as a file system
+ * path. This function, assesses whether a file is a file system path or not.
  *
- * @param filePath The file path
- * @param mediaType The media type (e.g. `text/plain`) or the corresponding extension (e.g. `txt`)
+ * If the string starts with `/`, `./` or `../` then it is assumed to be a path
+ * but the presence of the path is not checked. For all other strings, this function
+ * returns true if the file exists.
+ *
+ * @param content The string to assess.
+ */
+export function isPath(content: string): boolean {
+  if (
+    content.startsWith('/') ||
+    content.startsWith('./') ||
+    content.startsWith('../')
+  ) {
+    return true
+  }
+  if (fs.existsSync(content)) return true
+  return false
+}
+
+/**
+ * Match the compiler based on file name, extension name, media type or by content sniffing.
+ *
+ * Iterates through the list of compilers and returns the first that matches based on any
+ * of the above criteria.
+ *
+ * If the supplied format contains a forward slash then it is assumed to be a media type,
+ * otherwise an extension name.
+ *
+ * @param content The content as a file path (e.g. `../folder/file.txt`) or raw content
+ * @param format The format as a media type (e.g. `text/plain`) or extension name (e.g. `txt`)
  * @returns A promise that resolves to the `Compiler` to use
  */
 export async function match(
-  filePath?: string,
-  mediaType?: string
+  content?: string,
+  format?: string
 ): Promise<Compiler> {
-  let fileName = filePath ? path.basename(filePath) : undefined
-  let extName = filePath ? path.extname(filePath) : undefined
-
-  if (mediaType) {
-    // For convenience, media type may be supplied as an extension name e.g. `md`.
-    // So if the supplied value isn't a valid media type, look it up and if found then
-    // use that, otherwise use the supplied value as an extension name.
-    if (mime.getExtension(mediaType) === null) {
-      let inferredMediaType = mime.getType(mediaType)
-      if (!inferredMediaType) extName = mediaType
-      else mediaType = inferredMediaType
+  // Resolve variables used to match a compiler...
+  let fileName
+  let extName
+  let mediaType
+  // If the content is a path then begin with derived values
+  if (content && isPath(content)) {
+    fileName = path.basename(content)
+    extName = path.extname(content).slice(1)
+    mediaType = mime.getType(content) || undefined
+  }
+  // But override with supplied format (if any) assuming that
+  // media types always have a forward slash and extension names
+  // never do.
+  if (format) {
+    if (format.includes('/')) mediaType = format
+    else {
+      extName = format
+      mediaType = mime.getType(extName) || undefined
     }
-  } else if (filePath) {
-    // Try to determine the media type from the path
-    mediaType = mime.getType(filePath) || undefined
   }
 
   for (let compiler of compilerList) {
@@ -129,9 +165,11 @@ export async function match(
     ) {
       return compiler
     }
+
     if (extName && compiler.extNames && compiler.extNames.includes(extName)) {
       return compiler
     }
+
     if (
       mediaType &&
       compiler.mediaTypes &&
@@ -139,89 +177,144 @@ export async function match(
     ) {
       return compiler
     }
-    if (filePath && compiler.sniff && (await compiler.sniff(filePath))) {
+
+    if (content && compiler.sniff && (await compiler.sniff(content))) {
       return compiler
     }
   }
 
   let message = 'No compiler could be found'
-  if (filePath) message += ` for file path "${filePath}"`
-  if (mediaType) message += ` for media type "${mediaType}"`
+  if (content) message += ` for content "${content}"`
+  if (format) message += ` for format "${format}"`
   message += '.'
   throw new Error(message)
 }
 
+/**
+ * Is the file path, or media type handled? (i.e. is there a compiler for it?)
+ *
+ * @param content The file path
+ * @param format The media type
+ */
 export async function handled(
-  filePath?: string,
-  mediaType?: string
+  content?: string,
+  format?: string
 ): Promise<boolean> {
   try {
-    await match(filePath, mediaType)
+    await match(content, format)
     return true
   } catch (error) {
     return false
   }
 }
 
+/**
+ * Parse a virtual file to a `stencila.Node`
+ *
+ * @param file The `VFile` to parse
+ * @param content The file path
+ * @param format The media type
+ */
 export async function parse(
   file: VFile,
-  filePath?: string,
-  mediaType?: string
+  content?: string,
+  format?: string
 ): Promise<stencila.Node> {
-  const compiler = await match(filePath, mediaType)
+  const compiler = await match(content, format)
   return compiler.parse(file)
 }
 
+/**
+ * Unparse (i.e. serialize) a `stencila.Node` to a virtual file.
+ *
+ * @param node The node to unparse
+ * @param filePath The file path to unparse the node to.
+ *                 Only required for some compilers e.g. those unparsing to more than one file.
+ * @param format The format to unparse the node as.
+ *               If undefined then determined from filePath or file path.
+ */
 export async function unparse(
   node: stencila.Node,
   filePath?: string,
-  mediaType?: string
+  format?: string
 ): Promise<VFile> {
-  const compiler = await match(filePath, mediaType)
+  const compiler = await match(filePath, format)
   return compiler.unparse(node, filePath)
 }
 
+/**
+ * Load a `stencila.Node` from a string of content.
+ *
+ * @param content The content to load.
+ * @param format The format to load the content as.
+ */
 export async function load(
   content: string,
-  mediaType: string
+  format: string
 ): Promise<stencila.Node> {
   const file = vfile.load(content)
-  return parse(file, undefined, mediaType)
+  return parse(file, undefined, format)
 }
 
+/**
+ * Dump a `stencila.Node` to a string of content.
+ *
+ * @param node The node to dump.
+ * @param format The format to dump the node as.
+ */
 export async function dump(
   node: stencila.Node,
-  mediaType: string
+  format: string
 ): Promise<string> {
-  const file = await unparse(node, undefined, mediaType)
+  const file = await unparse(node, undefined, format)
   return vfile.dump(file)
 }
 
+/**
+ * Read a file to a `stencila.Node`.
+ *
+ * @param content The raw content or file path to read.
+ *                If undefined then read from standard input.
+ * @param format The format to read the file as.
+ *               If undefined then determined from content or file path.
+ */
 export async function read(
-  filePath?: string,
-  mediaType?: string
+  content?: string,
+  format?: string
 ): Promise<stencila.Node> {
   let file
-  if (filePath) file = await vfile.read(filePath)
-  else file = vfile.load(await getStdin())
-  return parse(file, filePath, mediaType)
+  if (content && isPath(content)) {
+    file = await vfile.read(content)
+  } else {
+    if (!content) content = await getStdin()
+    file = vfile.load(content)
+  }
+  return parse(file, content, format)
 }
 
+/**
+ * Write a `stencila.Node` to a file.
+ *
+ * @param node The node to write.
+ * @param filePath The file system path to write to.
+ *                 If undefined then write to standard output.
+ * @param format The format to write the node as.
+ */
 export async function write(
   node: stencila.Node,
   filePath?: string,
-  mediaType?: string
+  format?: string
 ): Promise<void> {
-  let file = await unparse(node, filePath, mediaType)
+  let file = await unparse(node, filePath, format)
   if (!filePath) console.log(vfile.dump(file))
   else await vfile.write(file, filePath)
 }
 
 /**
- * Convert from one format to another
+ * Convert content from one format to another.
  *
- * @param inp The input path. If missing stdin is used.
- * @param out The output path. If missing stdout is used.
+ * @param inp The input content (raw or file path). If undefined, standard input is used.
+ * @param out The output file path. If missing standard output is used.
  * @param from The format to convert the input from.
  * @param to The format to convert the output to.
  */

--- a/tests/fixtures/thing/simple/simple-thing.json
+++ b/tests/fixtures/thing/simple/simple-thing.json
@@ -1,0 +1,4 @@
+{
+  "type": "Thing",
+  "name": "Simple thing"
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,10 @@
+import path from 'path'
+
+/**
+ * Get the full path to a fixture directory or file
+ *
+ * @param fixture The subpath to the fixture
+ */
+export function fixture(fixture: string): string {
+  return path.join(__dirname, 'fixtures', fixture)
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,42 +1,158 @@
-import { dump, handled, load, match } from '../src'
+import stencila from '@stencila/schema'
+import fs from 'fs-extra'
+import {
+  compilerList,
+  convert,
+  dump,
+  handled,
+  isPath,
+  load,
+  match,
+  read,
+  write
+} from '../src'
 import * as json from '../src/json'
+import { create, VFile } from '../src/vfile'
 import * as yaml from '../src/yaml'
+import { fixture } from './helpers'
 
-test('match', async () => {
-  expect(await match('file.json')).toEqual(json)
-  expect(await match('dir/file.json')).toEqual(json)
-  expect(await match('file.foo', 'json')).toEqual(json)
-  expect(await match('file.foo', 'application/json')).toEqual(json)
-  expect(await match(undefined, 'application/json')).toEqual(json)
-  await expect(match('foo.bar')).rejects.toThrow(
-    'No compiler could be found for file path "foo.bar".'
-  )
-  await expect(match(undefined, 'foo')).rejects.toThrow(
-    'No compiler could be found for media type "foo".'
-  )
+test('isPath', () => {
+  expect(isPath('/')).toBe(true)
+  expect(isPath('/foo/bar.txt')).toBe(true)
+  expect(isPath('./')).toBe(true)
+  expect(isPath('./foo.txt')).toBe(true)
+  expect(isPath('../../')).toBe(true)
+  expect(isPath('../../foo.txt')).toBe(true)
 
-  expect(await match('file.yaml')).toEqual(yaml)
-  expect(await match('file.yml')).toEqual(yaml)
-  expect(await match(undefined, 'yaml')).toEqual(yaml)
-  expect(await match(undefined, 'yml')).toEqual(yaml)
+  // A file local to where tests are executed that does exist
+  expect(isPath('package.json')).toBe(true)
+
+  expect(isPath('foo.txt')).toBe(false)
+  expect(isPath('foo/bar.txt')).toBe(false)
+  expect(isPath('Foo bar baz')).toBe(false)
+})
+
+describe('match', () => {
+  // A dummy compiler for testing matching
+  const ssf = {
+    fileNames: ['super-special-file'],
+    extNames: ['ssf'],
+    mediaTypes: ['application/vnd.super-corp.super-special-file'],
+    sniff: async (content: string) => /^SSF:/.test(content),
+
+    // Required, but don't do anything
+    parse: async (file: VFile) => null,
+    unparse: async (node: stencila.Node, filePath?: string) => create()
+  }
+  compilerList.push(ssf)
+
+  it('works with file paths', async () => {
+    expect(await match('./file.json')).toEqual(json)
+    expect(await match('./dir/file.json')).toEqual(json)
+    expect(await match('./file.yaml')).toEqual(yaml)
+    expect(await match('./file.yml')).toEqual(yaml)
+    expect(await match('./file.ssf')).toEqual(ssf)
+    expect(await match('./super-special-file')).toEqual(ssf)
+  })
+
+  it('works with format as extension name', async () => {
+    expect(await match(undefined, 'json')).toEqual(json)
+    expect(await match(undefined, 'yaml')).toEqual(yaml)
+    expect(await match(undefined, 'yml')).toEqual(yaml)
+    expect(await match(undefined, 'ssf')).toEqual(ssf)
+  })
+
+  it('works with format as media type', async () => {
+    expect(await match(undefined, 'application/json')).toEqual(json)
+    expect(await match(undefined, 'text/yaml')).toEqual(yaml)
+    expect(
+      await match(undefined, 'application/vnd.super-corp.super-special-file')
+    ).toEqual(ssf)
+  })
+
+  it('works with file paths with format override', async () => {
+    expect(await match('./file.foo', 'json')).toEqual(json)
+    expect(await match('./file.yaml', 'application/json')).toEqual(json)
+    expect(await match('./file.json', 'text/yaml')).toEqual(yaml)
+    expect(await match('./file.json', 'ssf')).toEqual(ssf)
+  })
+
+  it('works with content sniffing', async () => {
+    expect(await match('SSF: woot!')).toEqual(ssf)
+  })
+
+  it('throws when unable to find a matching compiler', async () => {
+    await expect(match('./foo.bar')).rejects.toThrow(
+      'No compiler could be found for content "./foo.bar".'
+    )
+    await expect(match('foo')).rejects.toThrow(
+      'No compiler could be found for content "foo".'
+    )
+    await expect(match(undefined, 'foo')).rejects.toThrow(
+      'No compiler could be found for format "foo".'
+    )
+  })
 })
 
 test('handle', async () => {
-  expect(await handled('file.json')).toBeTruthy()
+  expect(await handled('./file.json')).toBeTruthy()
   expect(await handled(undefined, 'json')).toBeTruthy()
   expect(await handled(undefined, 'application/json')).toBeTruthy()
 
-  expect(await handled('file.foo')).toBeFalsy()
+  expect(await handled('./file.foo')).toBeFalsy()
   expect(await handled(undefined, 'foo')).toBeFalsy()
   expect(await handled(undefined, 'application/foo')).toBeFalsy()
 })
 
+/**
+ * The following are simple tests of the main API and don't do any
+ * actual conversion. See other tests for that.
+ */
+
+const simpleThing = {
+  type: 'Thing',
+  name: 'Simple thing'
+}
+
+const simpleThingJson = JSON.stringify(simpleThing, null, '  ')
+
 test('load', async () => {
-  expect(await load('{"type":"Thing"}', 'json')).toEqual({ type: 'Thing' })
+  expect(await load(simpleThingJson, 'json')).toEqual(simpleThing)
 })
 
 test('dump', async () => {
-  expect(await dump({ type: 'Thing' }, 'json')).toEqual(
-    '{\n  "type": "Thing"\n}'
-  )
+  expect(await dump(simpleThing, 'json')).toEqual(simpleThingJson)
+})
+
+describe('read', () => {
+  it('works with files', async () => {
+    expect(await read(fixture('thing/simple/simple-thing.json'))).toEqual(
+      simpleThing
+    )
+  })
+
+  it('works with content', async () => {
+    expect(await read(simpleThingJson, 'json')).toEqual(simpleThing)
+  })
+})
+
+describe('write', () => {
+  it('works with files', async () => {
+    const temp = '/tmp/simple-thing.json'
+    await write(simpleThing, temp)
+    expect(fs.readJsonSync(temp)).toEqual(simpleThing)
+  })
+
+  it('works with stdout', async () => {
+    const consoleLog = jest.spyOn(console, 'log')
+    await write(simpleThing, undefined, 'json')
+    expect(consoleLog).toHaveBeenCalledWith(simpleThingJson)
+  })
+})
+
+test('convert', async () => {
+  const inp = fixture('thing/simple/simple-thing.json')
+  const out = '/tmp/simple-thing.json'
+  await convert(inp, out)
+  expect(fs.readJsonSync(inp)).toEqual(fs.readJsonSync(out))
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -18,16 +18,21 @@ import { fixture } from './helpers'
 
 test('isPath', () => {
   expect(isPath('/')).toBe(true)
+  expect(isPath('C:\\')).toBe(true)
   expect(isPath('/foo/bar.txt')).toBe(true)
+  expect(isPath('C:\\foo\\bar.txt')).toBe(true)
   expect(isPath('./')).toBe(true)
+  expect(isPath('.\\')).toBe(true)
   expect(isPath('./foo.txt')).toBe(true)
   expect(isPath('../../')).toBe(true)
+  expect(isPath('..\\..\\')).toBe(true)
   expect(isPath('../../foo.txt')).toBe(true)
 
   // A file local to where tests are executed that does exist
   expect(isPath('package.json')).toBe(true)
 
   expect(isPath('foo.txt')).toBe(false)
+  expect(isPath('a: foo')).toBe(false)
   expect(isPath('foo/bar.txt')).toBe(false)
   expect(isPath('Foo bar baz')).toBe(false)
 })


### PR DESCRIPTION
This changes the API of several of the main functions:

- where appropriate change parameter `filePath` to `content`, which can be a string of raw content or a file path

- change parameter `mediaType` to `format` in places where either can be used and improve how the parameter is handled in `match`

This refactoring is mainly in preparation for adding compilers that act on plain text string, rather than files
- e.g. a compiler that detects a DOI and parses it into a `Article` by fetching meta data
- e.g. a compiler that [parses a string into a `Person`](https://github.com/stencila/schema/blob/fd19b920b48724731d5b1c7a7dd59b952f6d9caa/schema/organization/Person.ts#L15)
- moving the [implementation of the schema `parser` keyword](https://github.com/stencila/schema/blob/master/CONTRIBUTING.md#the-parser-keyword) into this repository (and moving all code out of the `schema` repo).

At the CLI it allows content to be provided as an argument, instead of in files or stdin e.g.

```bash
$ npx ts-node src/cli.ts "1,2,3" --from csv --to yaml
Converting from "1,2,3" to "yaml"

type: Datatable
name: Sheet1
columns:
  - type: DatatableColumn
    name: A
    values:
      - 1
  - type: DatatableColumn
    name: B
    values:
      - 2
  - type: DatatableColumn
    name: C
    values:
      - 3
```
