### PR TITLE
Add commands to generate CLI binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.sandbox
+/build
 /coverage
 /dist
 /docs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /node_modules
 /tests/**/*.to.*
 /tests/fixtures/rpng/*out.png
+/convert-deps.tgz

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/dubnium

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ check:
 
 build:
 	npm run build
+.PHONY: build
 
 docs:
 	npm run docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,6 +2194,24 @@
         "babel-plugin-jest-hoist": "^24.6.0"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "bail": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
@@ -2550,6 +2568,12 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3926,6 +3950,12 @@
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
+    "expand-template": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "dev": true
+    },
     "expect": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
@@ -4559,8 +4589,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4581,14 +4610,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4603,20 +4630,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4733,8 +4757,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4746,7 +4769,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4761,7 +4783,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4769,14 +4790,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4795,7 +4814,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4876,8 +4894,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4889,7 +4906,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4975,8 +4991,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5012,7 +5027,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5032,7 +5046,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5076,14 +5089,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5882,6 +5893,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indexof": {
@@ -9605,6 +9622,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multistream": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
+      "integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5"
+      }
+    },
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -10231,6 +10258,136 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pkg": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.3.8.tgz",
+      "integrity": "sha512-HhnMcHvGFf0VR4fJygqo1WTKztEK6m3UKS+O4NIM9tzbdgCfsAEpNncPlO9Gj6wAMbe9JC48UmzPBErpYSwckQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "7.2.3",
+        "babel-runtime": "6.26.0",
+        "chalk": "2.4.2",
+        "escodegen": "1.11.0",
+        "fs-extra": "7.0.1",
+        "globby": "8.0.2",
+        "into-stream": "4.0.0",
+        "minimist": "1.2.0",
+        "multistream": "2.1.1",
+        "pkg-fetch": "2.5.7",
+        "progress": "2.0.3",
+        "resolve": "1.6.0",
+        "stream-meter": "1.0.4"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+          "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "escodegen": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+          "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "into-stream": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
+          "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
+          "dev": true,
+          "requires": {
+            "from2": "^2.1.1",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+          "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -10238,6 +10395,74 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "pkg-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-2.5.7.tgz",
+      "integrity": "sha512-fm9aVV3ZRdFYTyFYcSHuKMuxPCVQ0MD9tbVxbvQzFTg1gwvV0KqWrFoj5enVVha94yP83I50XEBa90X8L9fE8w==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "~6.26.0",
+        "byline": "~5.0.0",
+        "chalk": "~2.4.1",
+        "expand-template": "~1.1.1",
+        "fs-extra": "~6.0.1",
+        "in-publish": "~2.0.0",
+        "minimist": "~1.2.0",
+        "progress": "~2.0.0",
+        "request": "~2.88.0",
+        "request-progress": "~3.0.0",
+        "semver": "~5.6.0",
+        "unique-temp-dir": "~1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fs-extra": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "please-upgrade-node": {
@@ -10882,6 +11107,15 @@
             "punycode": "^1.4.1"
           }
         }
+      }
+    },
+    "request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "dev": true,
+      "requires": {
+        "throttleit": "^1.0.0"
       }
     },
     "request-promise-core": {
@@ -11793,6 +12027,15 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-meter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
+      "integrity": "sha1-Uq+Vql6nYKJJFxZwTb/5D3Ov3R0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.1.4"
+      }
+    },
     "stream-to-async-iterator": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-async-iterator/-/stream-to-async-iterator-0.2.0.tgz",
@@ -12069,6 +12312,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
@@ -12625,6 +12874,12 @@
         }
       }
     },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
+    },
     "unbzip2-stream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
@@ -12722,6 +12977,17 @@
             "to-object-path": "^0.3.0"
           }
         }
+      }
+    },
+    "unique-temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+      "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "os-tmpdir": "^1.0.1",
+        "uid2": "0.0.3"
       }
     },
     "unist-builder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1477,6 +1477,15 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/tar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
+      "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -2757,6 +2766,12 @@
           }
         }
       }
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -4557,6 +4572,15 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "fs-monkey": {
@@ -9578,6 +9602,39 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -12223,6 +12280,35 @@
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Converters for Stencila components",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "convert": "./dist/cli.js"
+  },
   "scripts": {
     "lint": "tslint --project tsconfig.json --fix --format stylish ./src/**/*.ts",
     "test": "jest",
@@ -11,11 +14,20 @@
     "check": "npm run build:dist && npm run check:deps-used && npm run check:deps-unused",
     "check:deps-used": "dependency-check --missing .",
     "check:deps-unused": "dependency-check --unused --no-dev .",
-    "build": "npm run build:dist",
+    "build": "npm run build:dist && npm run build:bins",
     "build:dist": "tsc",
+    "build:bins": "pkg --out-path=build . && npm run postpkg",
+    "postpkg": "mkdir -p ./build/node_modules/puppeteer && cp -a ./node_modules/puppeteer/.local-chromium ./build/node_modules/puppeteer",
     "docs": "typedoc --options typedoc.js ./src",
     "prepublishOnly": "npm run lint && npm run test && npm run check && npm run docs",
     "clean": "rimraf coverage docs tests/**/*.to.*"
+  },
+  "pkg": {
+    "scripts": "./dist/**/*.js",
+    "assets": [
+      "./dist/**/*.json",
+      "./node_modules/@stencila/schema/dist/**/*.json"
+    ]
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/stencila/convert#readme",
@@ -83,6 +95,7 @@
     "jest": "^24.7.1",
     "jest-expect-message": "^1.0.2",
     "lint-staged": "^8.1.5",
+    "pkg": "^4.3.8",
     "prettier": "^1.16.4",
     "ts-jest": "^24.0.1",
     "ts-node": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "check:deps-unused": "dependency-check --unused --no-dev .",
     "build": "npm run build:dist && npm run build:bins",
     "build:dist": "tsc",
-    "build:bins": "pkg --out-path=build . && npm run postpkg",
-    "postpkg": "mkdir -p ./build/node_modules/puppeteer && cp -a ./node_modules/puppeteer/.local-chromium ./build/node_modules/puppeteer",
+    "build:tgz": "tar czf convert-deps.tgz node_modules/puppeteer/.local-chromium",
+    "build:bins": "npm run build:tgz && pkg --out-path=build .",
     "docs": "typedoc --options typedoc.js ./src",
     "prepublishOnly": "npm run lint && npm run test && npm run check && npm run docs",
     "clean": "rimraf coverage docs tests/**/*.to.*"
@@ -25,6 +25,7 @@
   "pkg": {
     "scripts": "./dist/**/*.js",
     "assets": [
+      "./convert-deps.tgz",
       "./dist/**/*.json",
       "./node_modules/@stencila/schema/dist/**/*.json"
     ]
@@ -87,6 +88,7 @@
     "@types/mime": "^2.0.1",
     "@types/parse5": "^5.0.0",
     "@types/puppeteer": "^1.12.3",
+    "@types/tar": "^4.0.0",
     "@types/unist": "^2.0.3",
     "@types/yargs": "^12.0.11",
     "dependency-check": "^3.3.0",
@@ -97,6 +99,7 @@
     "lint-staged": "^8.1.5",
     "pkg": "^4.3.8",
     "prettier": "^1.16.4",
+    "tar": "^4.4.8",
     "ts-jest": "^24.0.1",
     "ts-node": "^8.0.3",
     "tslint": "^5.15.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs'
+import './helpers/boot'
 import { convert } from './index'
 
 const VERSION = require('../package').version

--- a/src/helpers/boot.ts
+++ b/src/helpers/boot.ts
@@ -1,0 +1,61 @@
+/**
+ * Module for installing Convert native modules
+ *
+ * The [`pkg`](https://github.com/zeit/pkg) Node.js packager does not
+ * package native modules.  i.e `*.node` files. There are various ways to handle this but
+ * we found the easiest/safest was to simply copy the directories for the
+ * packages with native modules, from the host system, into directory where the
+ * binary is installed. This script does that via `convert-deps.tar.gz` which is
+ * packaged in the binary snapshot as an `asset`.
+ *
+ * See:
+ *   - https://github.com/stencila/convert/pull/47#issuecomment-489912132
+ *   - https://github.com/zeit/pkg/issues/329
+ *   - https://github.com/JoshuaWise/better-sqlite3/issues/173
+ *   - `package.json`
+ */
+import fs from 'fs-extra'
+import path from 'path'
+import puppeteer from 'puppeteer'
+import tar from 'tar'
+
+export const packaged =
+  ((process.mainModule && process.mainModule.id.endsWith('.exe')) ||
+    process.hasOwnProperty('pkg')) &&
+  fs.existsSync(path.join('/', 'snapshot'))
+
+export const home = packaged
+  ? path.dirname(process.execPath)
+  : path.dirname(__dirname)
+
+if (packaged && !fs.existsSync(path.join(home, 'node_modules'))) {
+  tar.x({
+    sync: true,
+    file: path.join('/', 'snapshot', 'convert', 'convert-deps.tgz'),
+    C: home
+  })
+}
+
+/**
+ * The following code is necessary to ensure the Chromium binary can be correctly
+ * found when bundled as a binary using [`pkg`](https://github.com/zeit/pkg).
+ * See: [`pkg-puppeteer`](https://github.com/rocklau/pkg-puppeteer)
+ */
+
+// Adapts the regex path to work on both Windows and *Nix platforms
+const pathRegex =
+  process.platform === 'win32'
+    ? /^.*?\\node_modules\\puppeteer\\\.local-chromium/
+    : /^.*?\/node_modules\/puppeteer\/\.local-chromium/
+
+export const chromiumPath = packaged
+  ? puppeteer
+      .executablePath()
+      .replace(
+        pathRegex,
+        path.join(
+          path.dirname(process.execPath),
+          path.join('node_modules', 'puppeteer', '.local-chromium')
+        )
+      )
+  : puppeteer.executablePath()

--- a/src/helpers/boot.ts
+++ b/src/helpers/boot.ts
@@ -55,7 +55,9 @@ export const chromiumPath = packaged
         pathRegex,
         path.join(
           path.dirname(process.execPath),
-          path.join('node_modules', 'puppeteer', '.local-chromium')
+          'node_modules',
+          'puppeteer',
+          '.local-chromium'
         )
       )
   : puppeteer.executablePath()

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -20,6 +20,7 @@ import pngEncode from 'png-chunks-encode'
 import pngExtract, { Chunk } from 'png-chunks-extract'
 import puppeteer from 'puppeteer'
 import { isBuffer } from 'util'
+import { chromiumPath } from './helpers/boot'
 import { dump, load } from './index'
 import { load as loadVFile, read as readVFile, VFile } from './vfile'
 
@@ -156,7 +157,9 @@ export async function unparse(node: stencila.Node): Promise<VFile> {
   let html = await dump(value, 'html')
 
   // Generate image of rendered HTML
-  const browser = await puppeteer.launch()
+  const browser = await puppeteer.launch({
+    executablePath: chromiumPath
+  })
   const page = await browser.newPage()
   // TODO Develop CSS for tables etc
   const css = '#target {font: sans #777}'


### PR DESCRIPTION
Closes #45 

Need to do some testing of the binary on other platforms.

There have been ongoing reports of [issues with Puppeteer and PKG](https://github.com/zeit/pkg/issues/204), so would be nice to verify functionalities which depend on Puppeteer (e.g. rPNG generation).

Another aspect is that the binary generation gives the following warning:
``` sh
> Warning Cannot include directory %1 into executable.
  The directory must be distributed with executable as %2.
  node_modules/puppeteer/.local-chromium
  path-to-executable/puppeteer
```

The command `npm run postpkg` copies Puppeteer/Chrome into the required folder, but it defeats the purpose of having a single binary as now we have two binaries we'd need to ship.
In addition, the puppeteer binary will likely have to change depending on the targeted platform, so adds a more overhead during the build process. 