### PR TITLE
[WIP] Conversion of source code nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4906,6 +4906,11 @@
         "class-list": "~0.1.1"
       }
     },
+    "html-element-attributes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-2.1.0.tgz",
+      "integrity": "sha512-uWNlZuzM3MfRvZLAHWUzwwU6He2NvX9szpXwjG7+hoVqZzY3e0vc6mlujiSnJ/i9zVFZDhBDN33Pm9HNEzcyPg=="
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -7175,6 +7180,11 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true
+    },
+    "md-attr-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/md-attr-parser/-/md-attr-parser-1.2.1.tgz",
+      "integrity": "sha512-dZqt2L4Q7FUcx6ZcuownAxa74Y7d5jcsHRB2MIgQ0vT10Pa+/0Som6hhJ+jgAjP3vnFtrd4aO+ZMc5K7QVfbiQ=="
     },
     "mdast-util-compact": {
       "version": "1.0.2",
@@ -12660,6 +12670,15 @@
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "remark-attr": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/remark-attr/-/remark-attr-0.8.3.tgz",
+      "integrity": "sha512-JMP6rmLwhj5VmDRG99kGr+HNXQ6MmAs+UojeAHGMQFiIitEmJZBkmgOBsWadxu/RTACD4XnMuJXY1QWEFdw31A==",
+      "requires": {
+        "html-element-attributes": "^2.0.0",
+        "md-attr-parser": "^1.2.1"
       }
     },
     "remark-frontmatter": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "png-chunks-encode": "^1.0.0",
     "png-chunks-extract": "^1.0.0",
     "puppeteer": "^1.14.0",
+    "remark-attr": "^0.8.3",
     "remark-frontmatter": "^1.3.1",
     "remark-generic-extensions": "^1.4.0",
     "remark-parse": "^6.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import stencila from '@stencila/schema'
+import * as stencila from '@stencila/schema'
 import mime from 'mime'
 import path from 'path'
 import * as csv from './csv'
@@ -16,6 +16,7 @@ import * as rpng from './rpng'
 import * as tdp from './tdp'
 import * as vfile from './vfile'
 import * as xlsx from './xlsx'
+import * as rmd from './xmd'
 import * as yaml from './yaml'
 
 type VFile = vfile.VFile
@@ -40,6 +41,7 @@ export const compilerList: Array<Compiler> = [
   latex,
   odt,
   md,
+  rmd,
 
   // Images
   rpng,
@@ -133,7 +135,10 @@ export async function match(
   // If the content is a path then begin with derived values
   if (content && vfile.isPath(content)) {
     fileName = path.basename(content)
-    extName = path.extname(content).slice(1)
+    extName = path
+      .extname(content)
+      .slice(1)
+      .toLowerCase()
     mediaType = mime.getType(content) || undefined
   }
   // But override with supplied format (if any) assuming that

--- a/src/xmd.ts
+++ b/src/xmd.ts
@@ -1,0 +1,135 @@
+/**
+ * # Compiler for XMarkdown
+ *
+ * "XMarkdown" is our name for RMarkdown-like formats, that is, RMarkdown but extended to language
+ * X, where X includes Python, Javascript, etc. See https://bookdown.org/yihui/rmarkdown/language-engines.html
+ *
+ * In RMarkdown, R code is embedded in "code chunks". There are two types of code chunks: inline and block.
+ * In XMarkdown, we allow both inline and block chunks to be defined in various languages using
+ * the usual language labels e.g. ``r``, ``py``, ``js``.
+ *
+ * ## Inline code chunks
+ *
+ * An inline code chunk is equivalent to Stencila's `CodeExpr`.
+ * They are declared using Markdown code spans prefixed by the language label e.g.
+ *
+ * ```markdown
+ * The answer is `r x * y`
+ * ```
+ *
+ * Inline code chunks are decoded to a `CodeExpr` with `language` and `text` properties set e.g.
+ *
+ * ```json
+ * {
+ *   "type": "CodeExpr",
+ *   "language": "r",
+ *   "text": "x * y"
+ * }
+ * ```
+ *
+ * ## Block code chunks
+ *
+ * A block code chunks is equivalent to Stencila's `CodeChunk`.
+ * They are declared using Markdown fenced code blocks with attributes starting
+ * with the language label and, optionally, a chunk label and other chunk options e.g.
+ *
+ * ~~~markdown
+ * ```{r myplot, fig.width=6, fig.height=7}
+ * plot(x,y)
+ * ```
+ * ~~~
+ *
+ * Here `myplot` is the chunk label and `fig.width=6, fig.height=7` are chunk options.
+ * A list of chunk options, recognized by the RMarkdown rendering engine, Knitr,
+ * is available at http://yihui.name/knitr/options/.
+ *
+ * Block code chunks are decoded to a `CodeChunk` with `language` and `text` properties
+ * set. The chunk label, if defined is used for the `name` property and other
+ * options go into the `meta` property e.g.
+ *
+ * ```json
+ * {
+ *   "type": "CodeChunk",
+ *   "language": "r",
+ *   "name": "myplot",
+ *   "meta": {
+ *      "fig.width": "6",
+ *      "fig.width": "7"
+ *   },
+ *   "text": "plot(x,y)"
+ * }
+ * ```
+ *
+ * ## Implementation
+ *
+ * This compiler works by transforming XMarkdown to Commonmark with `!expr` and `!chunk`
+ * extensions. The `parse` function does the transformation using regexes prior to passing
+ * the transformed XMarkdown to the `md` compiler.
+ *
+ * @module xmd
+ */
+
+import * as stencila from '@stencila/schema'
+import * as md from './md'
+import { dump, load, VFile } from './vfile'
+
+export const mediaTypes = []
+export const extNames = ['xmd', 'rmd']
+
+export async function parse(file: VFile): Promise<stencila.Node> {
+  const xmd = dump(file)
+  // Inline code chunks...
+  let cmd = xmd.replace(/`([a-z]+)\s+([^`]*)`/g, (match, lang, text) => {
+    // ...are replaced with inline code with `lang` attr
+    return `\`${text}\`{.exec lang=${lang}}`
+  })
+  // Block code chunks...
+  cmd = cmd.replace(
+    /```\s*{([a-z]+)\s*([^}]*)}\s*\n(.*)\n```\n/gm,
+    (match, lang, options, text) => {
+      // Replace with a Commonmark backtick fenced code block with an
+      // "info string" (does not have curly braces)
+      let md = '``` ' + lang + ' .exec'
+      if (options) md += ` ${options}`
+      return md + '\n' + text + '\n```\n'
+    }
+  )
+  return md.parse(load(cmd))
+}
+
+export async function unparse(
+  node: stencila.Node,
+  filePath?: string
+): Promise<VFile> {
+  const transformed = transform(node)
+  const mdFile = await md.unparse(transformed)
+  const cmd = dump(mdFile)
+  const xmd = cmd.replace(
+    /^\`\`\`([^\s]+)/gm,
+    (match, lang) => `\`\`\` {${lang}}`
+  )
+  return load(xmd)
+
+  function transform(node: any): stencila.Node {
+    if (node === null || typeof node !== 'object') return node
+    if (node.type === 'CodeExpr') {
+      const code: stencila.Code = {
+        type: 'Code',
+        value: `${node.languages[0]} ${node.text}`
+      }
+      return code
+    }
+    if (node.type === 'CodeChunk') {
+      const codeBlock: stencila.CodeBlock = {
+        type: 'CodeBlock',
+        language: node.languages[0],
+        value: node.text
+      }
+      return codeBlock
+    }
+    for (const [key, child] of Object.entries(node)) {
+      node[key] = transform(child)
+    }
+    return node
+  }
+}

--- a/tests/xmd.test.ts
+++ b/tests/xmd.test.ts
@@ -1,0 +1,76 @@
+import { dump, load } from '../src/vfile'
+import { parse, unparse } from '../src/xmd'
+
+test('parse', async () => {
+  const p = async (xmd: any) => await parse(load(xmd))
+  expect(await p(kitchenSink.xmd)).toEqual(kitchenSink.node)
+})
+
+test('unparse', async () => {
+  const u = async (node: any) => dump(await unparse(node))
+  expect(await u(kitchenSink.node)).toEqual(kitchenSink.xmd)
+})
+
+// An example intended for testing progressively added parser/unparser pairs
+const kitchenSink = {
+  xmd: `---
+authors: []
+---
+
+# Inline chunks
+
+Simple \`r x * y\`
+
+With parentheses and brackets \`python sum(x*y)[1]\`
+
+# Block chunks
+
+\`\`\` {r}
+plot(1)
+\`\`\`
+`,
+
+  node: {
+    type: 'Article',
+    authors: [],
+    content: [
+      {
+        type: 'Heading',
+        depth: 1,
+        content: ['Inline chunks']
+      },
+      {
+        type: 'Paragraph',
+        content: [
+          'Simple ',
+          {
+            type: 'CodeExpr',
+            languages: ['r'],
+            text: 'x * y'
+          }
+        ]
+      },
+      {
+        type: 'Paragraph',
+        content: [
+          'With parentheses and brackets ',
+          {
+            type: 'CodeExpr',
+            languages: ['python'],
+            text: 'sum(x*y)[1]'
+          }
+        ]
+      },
+      {
+        type: 'Heading',
+        depth: 1,
+        content: ['Block chunks']
+      },
+      {
+        type: 'CodeChunk',
+        languages: ['r'],
+        text: 'plot(1)'
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR aims to stabilize and more fully implement conversion of source code nodes e.g. `CodeChunk`

This PR depends on a sister PR in the schema repo:  https://github.com/stencila/schema/pull/64. It's necessary (and easier during active development) to link that repo after pulling this branch:

```bash
npm install
npm link @stencila/schema
```

Then, each time you make a change in the `schema` repo, build the Typescript definitions to make them available here:

```bash
npm run build:ts
```