### PR TITLE
Normalize use of text and title for images

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -520,24 +520,26 @@ function unparseCode(code: stencila.Code): HTMLElement {
 }
 
 /**
- * Parse a `<img>` element to a `stencila.ImageObject`.
+ * Parse a HTML `<img>` element to a Stencila `ImageObject`.
  */
 function parseImage(elem: HTMLImageElement): stencila.ImageObject {
   const image: stencila.ImageObject = {
     type: 'ImageObject',
     contentUrl: elem.src
   }
-  if (elem.alt) image.caption = elem.alt
+  if (elem.title) image.title = elem.title
+  if (elem.alt) image.text = elem.alt
   return image
 }
 
 /**
- * Unparse a `stencila.ImageObject` to a `<img>` element.
+ * Unparse a Stencila `ImageObject` to a HTML `<img>` element.
  */
 function unparseImageObject(image: stencila.ImageObject): HTMLImageElement {
   return h('img', {
-    alt: image.caption,
-    src: image.contentUrl
+    src: image.contentUrl,
+    title: image.title,
+    alt: image.text
   })
 }
 

--- a/src/md.ts
+++ b/src/md.ts
@@ -700,22 +700,26 @@ function unparseCode(code: stencila.Code): MDAST.InlineCode {
  * Parse a `MDAST.Image` to a `stencila.ImageObject`
  */
 function parseImage(image: MDAST.Image): stencila.ImageObject {
-  return {
+  const imageObject: stencila.ImageObject = {
     type: 'ImageObject',
-    contentUrl: image.url,
-    caption: image.alt
+    contentUrl: image.url
   }
+  if (image.title) imageObject.title = image.title
+  if (image.alt) imageObject.text = image.alt
+  return imageObject
 }
 
 /**
  * Unparse a `stencila.ImageObject` to a `MDAST.Image`
  */
-function unparseImageObject(image: stencila.ImageObject): MDAST.Image {
-  return {
+function unparseImageObject(imageObject: stencila.ImageObject): MDAST.Image {
+  const image: MDAST.Image = {
     type: 'image',
-    url: image.contentUrl || '',
-    alt: image.caption || ''
+    url: imageObject.contentUrl || ''
   }
+  if (imageObject.title) image.title = imageObject.title
+  if (imageObject.text) image.alt = imageObject.text
+  return image
 }
 
 /**

--- a/tests/gdoc.test.ts
+++ b/tests/gdoc.test.ts
@@ -300,8 +300,8 @@ const kitchenSink = {
           {
             type: 'ImageObject',
             contentUrl: 'https://lh3.googleusercontent.com/just-an-example',
-            caption: 'The title',
-            description: 'The description'
+            title: 'The title',
+            text: 'The description'
           }
         ]
       },

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -38,7 +38,8 @@ const kitchenSink = {
     <p>A paragraph with <a href="https://example.org">a <em>rich</em> link</a>.</p>
     <p>A paragraph with <q cite="https://example.org">quote</q>.</p>
     <p>A paragraph with <code class="language-python"># code</code>.</p>
-    <p>A paragraph with an image <img alt="caption" src="https://example.org/image.png">.</p>
+    <p>A paragraph with an image <img src="https://example.org/image.png" title="title"
+        alt="alt text">.</p>
     <p>Paragraph with a <stencila-boolean>true</stencila-boolean> and a <stencila-boolean>false
       </stencila-boolean>.</p>
     <p>A paragraph with other data: a <stencila-null>null</stencila-null>, a <stencila-number>3.14
@@ -176,7 +177,8 @@ const inc = (n) => n + 1</code></pre>
           {
             type: 'ImageObject',
             contentUrl: 'https://example.org/image.png',
-            caption: 'caption'
+            title: 'title',
+            text: 'alt text'
           },
           '.'
         ]

--- a/tests/md.test.ts
+++ b/tests/md.test.ts
@@ -52,7 +52,7 @@ A paragraph with [a _rich_ link](https://example.org).
 
 A paragraph with !quote[quote](https://example.org).
 
-A paragraph with an image ![caption](https://example.org/image.png).
+A paragraph with an image ![alt text](https://example.org/image.png "title").
 
 A paragraph with !true and !false boolean values.
 
@@ -178,7 +178,8 @@ x = {}
           {
             type: 'ImageObject',
             contentUrl: 'https://example.org/image.png',
-            caption: 'caption'
+            title: 'title',
+            text: 'alt text'
           },
           '.'
         ]

--- a/tests/pandoc.test.ts
+++ b/tests/pandoc.test.ts
@@ -18,6 +18,7 @@ test('parse', async () => {
   const p = async (pdoc: any) => await parse(load(JSON.stringify(pdoc)))
   expect(await p(kitchenSink.pdoc)).toEqual(kitchenSink.node)
   expect(await p(collapseSpaces.pdoc)).toEqual(collapseSpaces.node)
+  expect(await p(imageInlinesToString.pdoc)).toEqual(imageInlinesToString.node)
 })
 
 test('unparse', async () => {
@@ -168,7 +169,14 @@ const kitchenSink: testCase = {
           str(' and '),
           { t: 'Link', c: [emptyAttrs, [], ['url', 'title']] },
           str(' and '),
-          { t: 'Image', c: [emptyAttrs, [], ['url', 'title']] },
+          {
+            t: 'Image',
+            c: [
+              emptyAttrs,
+              [str('alt text')],
+              ['http://example.org/image.png', 'title']
+            ]
+          },
           str('.')
         ]
       },
@@ -277,9 +285,9 @@ const kitchenSink: testCase = {
           ' and ',
           {
             type: 'ImageObject',
-            caption: 'title',
-            content: [],
-            contentUrl: 'url'
+            contentUrl: 'http://example.org/image.png',
+            title: 'title',
+            text: 'alt text'
           },
           '.'
         ]
@@ -412,6 +420,67 @@ const collapseSpaces: testCase = {
           { type: 'Strong', content: ['Strong then space'] },
           ' ',
           '.'
+        ]
+      }
+    ]
+  }
+}
+
+// Test that where necessary Pandoc inline nodes are parsed to strings
+const imageInlinesToString: testCase = {
+  pdoc: {
+    'pandoc-api-version': Pandoc.Version,
+    meta: {},
+    blocks: [
+      {
+        t: 'Para',
+        c: [
+          {
+            t: 'Image',
+            c: [
+              emptyAttrs,
+              [
+                {
+                  t: 'Emph',
+                  c: [str('emphasis')]
+                },
+                {
+                  t: 'Space',
+                  c: undefined
+                },
+                {
+                  t: 'Strong',
+                  c: [str('strong')]
+                },
+                {
+                  t: 'Space',
+                  c: undefined
+                },
+                {
+                  t: 'Quoted',
+                  c: [{ t: Pandoc.QuoteType.SingleQuote }, [str('quoted')]]
+                }
+              ],
+              ['http://example.org/image.png', 'title']
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  node: {
+    type: 'Article',
+    authors: [],
+    content: [
+      {
+        type: 'Paragraph',
+        content: [
+          {
+            type: 'ImageObject',
+            contentUrl: 'http://example.org/image.png',
+            title: 'title',
+            text: 'emphasis strong quoted'
+          }
         ]
       }
     ]


### PR DESCRIPTION
This normalises (?, unifies?) the use of `title` and `text` properties for `ImageObject` across different formats. Previously we were using `caption` and `context` and `description` as target properties for `text` which caused inconsistencies when converting between formats.

Now, for example, for the Stencila `ImageObject` node:
```javascript
{
  type: 'ImageObject',
  contentUrl: 'https://example.org/image.png',
  title: 'title',
  text: 'alt text'
}
```

You get this HTML:
```html
<img src="https://example.org/image.png" 
          title="title"
          alt="alt text">
```

And this Pandoc AST:
```javascript
{
  t: 'Image',
  c: [
    emptyAttrs,
    [str('alt text')],
    ['http://example.org/image.png', 'title']
  ]
}
```

And a `gdoc` node that's consistent, but is rather complicated and not worth showing here :)