### PR TITLE
Add JSON5 compiler

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -589,14 +589,14 @@ function unparseNumber(value: number): HTMLElement {
  * Parse a `<stencila-array>` element to a `array`.
  */
 function parseArray(elem: HTMLElement): Array<any> {
-  return JSON.parse(elem.innerHTML || '[]')
+  return JSON5.parse(elem.innerHTML || '[]')
 }
 
 /**
  * Unparse a `array` to a `<stencila-array>` element.
  */
 function unparseArray(value: Array<any>): HTMLElement {
-  return h('stencila-array', JSON.stringify(value))
+  return h('stencila-array', JSON5.stringify(value))
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as gdoc from './gdoc'
 import * as html from './html'
 import * as jats from './jats'
 import * as json from './json'
+import * as json5 from './json5'
 import * as latex from './latex'
 import * as md from './md'
 import * as ods from './ods'
@@ -48,6 +49,7 @@ export const compilerList: Array<Compiler> = [
   html,
   yaml,
   pandoc,
+  json5,
   json
 ]
 

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -1,0 +1,62 @@
+/**
+ * # JSON5 compiler
+ *
+ * [JSON5](https://json5.org/) is "JSON for Humans":
+ *
+ * > The JSON5 Data Interchange Format (JSON5) is a superset of JSON that aims
+ * > to alleviate some of the limitations of JSON by expanding its syntax to
+ * > include some productions from ECMAScript 5.1.
+ *
+ * This compiler is primarily targeted at developers.
+ * Given that it is more forgiving and it has less typing overhead,
+ * JSON5 can be a little more convenient than JSON for quickly testing
+ * unparsing of Stencila nodes e.g
+ *
+ * ```bash
+ * stencila convert "{type:'ImageObject', contentUrl: 'https://example.org', text: 'alt', title: 'title'}" --from json5 --to html
+ * ```
+ *
+ * Versus using JSON:
+ *
+ * ```bash
+ * stencila convert '{"type":"ImageObject", "contentUrl": "https://example.org", "text": "alt", "title": "title"}' --from json --to html
+ * ```
+ *
+ * @module json5
+ */
+
+/** A comment required for above to be included in docs.
+ * See https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/300
+ */
+
+import stencila from '@stencila/schema'
+import json5 from 'json5'
+import { dump, load, VFile } from './vfile'
+
+/**
+ * The media types that this compiler can parse/unparse.
+ */
+export const mediaTypes = ['application/json5']
+
+// The above media type is registered in the `mime` module
+// so there is no need to specify `extNames`
+
+/**
+ * Parse a `VFile` with JSON5 content to a Stencila `Node`.
+ *
+ * @param file The `VFile` to parse
+ * @returns A promise that resolves to a Stencila `Node`
+ */
+export async function parse(file: VFile): Promise<stencila.Node> {
+  return json5.parse(dump(file))
+}
+
+/**
+ * Unparse a Stencila `Node` to a `VFile` with JSON5 content.
+ *
+ * @param thing The Stencila `Node` to unparse
+ * @returns A promise that resolves to a `VFile`
+ */
+export async function unparse(node: stencila.Node): Promise<VFile> {
+  return load(json5.stringify(node, null, '  '))
+}

--- a/src/md.ts
+++ b/src/md.ts
@@ -13,6 +13,7 @@
 
 import * as stencila from '@stencila/schema'
 import * as yaml from 'js-yaml'
+import JSON5 from 'json5'
 import * as MDAST from 'mdast'
 // @ts-ignore
 import compact from 'mdast-util-compact'
@@ -818,7 +819,7 @@ function unparseNumber(value: number): Extension {
  */
 function parseArray(ext: Extension): Array<any> {
   const items = ext.argument || ext.content || ''
-  const array = JSON.parse(`[${items}]`)
+  const array = JSON5.parse(`[${items}]`)
   return array
 }
 
@@ -826,7 +827,7 @@ function parseArray(ext: Extension): Array<any> {
  * Unparse an `array` to a `!array` inline extension
  */
 function unparseArray(value: Array<any>): Extension {
-  const argument = JSON.stringify(value).slice(1, -1)
+  const argument = JSON5.stringify(value).slice(1, -1)
   return { type: 'inline-extension', name: 'array', argument }
 }
 
@@ -852,14 +853,14 @@ function parseObject(ext: Extension): object {
     }
     if (Object.keys(props).length > 0) return props
   }
-  return JSON.parse(`{${ext.argument || ext.content}}`)
+  return JSON5.parse(`{${ext.argument || ext.content}}`)
 }
 
 /**
  * Unparse an `object` to a `!object` inline extension
  */
 function unparseObject(value: object): Extension {
-  const argument = JSON.stringify(value).slice(1, -1)
+  const argument = JSON5.stringify(value).slice(1, -1)
   return { type: 'inline-extension', name: 'object', argument }
 }
 

--- a/tests/json5.test.ts
+++ b/tests/json5.test.ts
@@ -1,0 +1,6 @@
+import * as yaml from '../src/yaml'
+import articleSimple from './fixtures/article-simple'
+
+test('invertible', async () => {
+  await expect(yaml).toInvert(articleSimple)
+})

--- a/tests/json5.test.ts
+++ b/tests/json5.test.ts
@@ -1,6 +1,6 @@
-import * as yaml from '../src/yaml'
+import * as json5 from '../src/json5'
 import articleSimple from './fixtures/article-simple'
 
 test('invertible', async () => {
-  await expect(yaml).toInvert(articleSimple)
+  await expect(json5).toInvert(articleSimple)
 })

--- a/tests/md.test.ts
+++ b/tests/md.test.ts
@@ -56,7 +56,7 @@ A paragraph with an image ![alt text](https://example.org/image.png "title").
 
 A paragraph with !true and !false boolean values.
 
-A paragraph with a !null, a !number(42.2), an !array(1,2), and an !object("a":"1","b":"two").
+A paragraph with a !null, a !number(42.2), an !array(1,2), and an !object(a:'1',b:'two').
 
 > A block quote
 


### PR DESCRIPTION
[JSON5](https://json5.org/) is "JSON for Humans":

> The JSON5 Data Interchange Format (JSON5) is a superset of JSON that aims
> to alleviate some of the limitations of JSON by expanding its syntax to
> include some productions from ECMAScript 5.1.

This compiler is primarily targeted at developers. Given that it is more forgiving and it has less typing overhead, JSON5 can be a little more convenient than JSON for quickly testing unparsing of Stencila nodes e.g

```bash
stencila convert "{type:'ImageObject', contentUrl: 'https://example.org', text: 'alt', title: 'title'}" --from json5 --to html
```

Versus using JSON:

```bash
stencila convert '{"type":"ImageObject", "contentUrl": "https://example.org", "text": "alt", "title": "title"}' --from json --to html
```

I found myself getting frustrated with having to use JSON for this type of thing, wanted JSON5, so implemented it.

This PR also ensures consistency in use of JSON5 for representing arrays and objects in Markdown and HTML.