### PR TITLE
Add PDF encoder

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,12 @@ yargs
       const from = argv.from
       const to = argv.to
       await convert(inp, out, { from, to })
+
+      // Trigger a clean up
+      //   "The 'beforeExit' event is not emitted for conditions causing
+      //   explicit termination, such as calling process.exit() or uncaught
+      //   exceptions."
+      process.emit('beforeExit', 0)
     }
   )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import * as md from './md'
 import * as ods from './ods'
 import * as odt from './odt'
 import * as pandoc from './pandoc'
+import * as pdf from './pdf'
 import * as rpng from './rpng'
 import * as tdp from './tdp'
 import * as vfile from './vfile'
@@ -36,17 +37,18 @@ export const compilerList: Array<Compiler> = [
 
   // Articles, textual documents etc
   docx,
-  jats,
   gdoc,
+  html,
+  jats,
   latex,
-  odt,
   md,
+  odt,
+  pdf,
 
   // Images
   rpng,
 
-  // "Generic" formats
-  html,
+  // Data interchange formats
   yaml,
   pandoc,
   json5,

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,0 +1,63 @@
+/**
+ * # PDF unparser
+ *
+ * @module pdf
+ */
+
+/** A comment required for above to be included in docs.
+ * See https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/300
+ */
+
+import * as stencila from '@stencila/schema'
+import { dump } from './index'
+import * as puppeteer from './puppeteer'
+import { load, VFile } from './vfile'
+
+/**
+ * The media types that this compiler can parse/unparse.
+ */
+export const mediaTypes = ['application/pdf']
+
+// The above media type is registered in the `mime` module
+// so there is no need to specify `extNames`
+
+/**
+ * This function is required (currently) but is (and probably never will be)
+ * implemented.
+ */
+export async function parse(file: VFile): Promise<stencila.Node> {
+  throw new Error(`Parsing of PDF files is not supported.`)
+}
+
+// The Puppeteer page that will be used to generate PDFs
+export const browser = puppeteer.page()
+
+/**
+ * Unparse a Stencila `Node` to a `VFile` with PDF content.
+ *
+ * @param node The Stencila `Node` to unparse
+ * @param filePath The file system path to write the PDF to
+ * @returns A promise that resolves to a `VFile`
+ */
+export async function unparse(
+  node: stencila.Node,
+  filePath?: string
+): Promise<VFile> {
+  const html = await dump(node, 'html')
+
+  const page = await browser()
+  await page.setContent(html, { waitUntil: 'networkidle0' })
+  const buffer = await page.pdf({
+    path: filePath,
+    format: 'A4',
+    printBackground: true,
+    margin: {
+      top: '2.54cm',
+      bottom: '2.54cm',
+      left: '2.54cm',
+      right: '2.54cm'
+    }
+  })
+
+  return load(buffer)
+}

--- a/src/puppeteer.ts
+++ b/src/puppeteer.ts
@@ -1,0 +1,54 @@
+import puppeteer from 'puppeteer'
+import { chromiumPath } from './boot'
+
+/**
+ * Get an instance of a Puppeteer web browser `Page`.
+ *
+ * @returns A thunk that returns the same `puppeteer.Page`
+ *          each time that it is called
+ */
+export function page() {
+  let browser: puppeteer.Browser | undefined
+  let page: puppeteer.Page | undefined
+
+  /**
+   * Startup the browser and create the
+   * page if it isn't already.
+   */
+  async function startup() {
+    if (!browser) {
+      browser = await puppeteer.launch({
+        executablePath: chromiumPath,
+        headless: true
+      })
+    }
+    if (!page) {
+      page = await browser.newPage()
+    }
+    return page
+  }
+
+  /**
+   * Close the browser.
+   */
+  async function shutdown() {
+    if (browser) {
+      await browser.close()
+      browser = undefined
+    }
+    page = undefined
+  }
+
+  // Always shutdown before exiting the Node process
+  // We use `beforeExit` because async operations are not supported
+  // by `exit`.
+  // See https://nodejs.org/api/process.html#process_event_beforeexit
+  process.on('beforeExit', shutdown)
+
+  function thunk(): Promise<puppeteer.Page>
+  function thunk(close: 'close'): Promise<void>
+  function thunk(close?: 'close') {
+    return close ? shutdown() : startup()
+  }
+  return thunk
+}

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -1,6 +1,13 @@
 import path from 'path'
 import * as pdf from '../src/pdf'
+import { create } from '../src/vfile'
 import articleSimple from './fixtures/article-simple'
+
+test('parse', async () => {
+  await expect(pdf.parse(create())).rejects.toThrow(
+    /Parsing of PDF files is not supported/
+  )
+})
 
 test('unparse', async () => {
   const output = path.join(__dirname, 'output', 'pdf-unparse.pdf')

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -1,0 +1,15 @@
+import path from 'path'
+import * as pdf from '../src/pdf'
+import articleSimple from './fixtures/article-simple'
+
+test('unparse', async () => {
+  const output = path.join(__dirname, 'output', 'pdf-unparse.pdf')
+  const doc = await pdf.unparse(articleSimple, output)
+
+  expect(Buffer.isBuffer(doc.contents)).toBe(true)
+  expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')
+})
+
+afterAll(async () => {
+  await pdf.browser('close')
+})

--- a/tests/puppeteer.test.ts
+++ b/tests/puppeteer.test.ts
@@ -1,0 +1,14 @@
+import { page } from '../src/puppeteer'
+
+test('page', async () => {
+  const p = page()
+
+  const q = await p()
+  expect(q).toBeTruthy()
+  // Get the same page the second time
+  expect(await p()).toBe(q)
+
+  expect(await p('close')).toBeUndefined()
+  // Can call a second time without blowing up
+  expect(await p('close')).toBeUndefined()
+})


### PR DESCRIPTION
This adds a PDF unparser (but not a parser). It partly addresses https://github.com/stencila/convert/issues/53 but does not use Paged.js (that will be dealt with as part of https://github.com/stencila/convert/issues/62).

This also implements an approach to make use of Puppeteer more efficient as described in https://github.com/stencila/convert/issues/61. If the solution here looks alright, we can apply it to that issue next.